### PR TITLE
Improves grid printing

### DIFF
--- a/grid/index.html
+++ b/grid/index.html
@@ -25,13 +25,11 @@
             background-color: var(--grist-theme-bg);
             color: var(--grist-theme-text);
             font-size: 14px;
-            height: 100vh;
             overflow: hidden;
         }
 
         .widget-container {
             background: var(--grist-theme-bg);
-            height: 100vh;
             display: flex;
             flex-direction: column;
             overflow: hidden;

--- a/grid/index.html
+++ b/grid/index.html
@@ -25,7 +25,6 @@
             background-color: var(--grist-theme-bg);
             color: var(--grist-theme-text);
             font-size: 14px;
-            overflow: hidden;
         }
 
         .widget-container {


### PR DESCRIPTION
When the table is large, the printout is truncated. The CSS property height: 100vh; of the body element and the .widget-container elements is the cause of this and does not seem to be useful for proper display on screen.